### PR TITLE
[sailfishos][embedlite] Fix AsyncPanZoomController fling state. JB#61045

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -326,7 +326,7 @@ EmbedLiteView::ReceiveInputEvent(const EmbedTouchInput &aEvent)
   NS_ENSURE_TRUE(mViewImpl,);
 
   mozilla::MultiTouchInput multiTouchInput(static_cast<mozilla::MultiTouchInput::MultiTouchType>(aEvent.type),
-                                           aEvent.timeStamp, TimeStamp(), 0);
+                                           aEvent.timeStamp, TimeStamp::Now(), 0);
 
   for (const mozilla::embedlite::TouchData &touchData : aEvent.touches) {
     nsIntPoint point = nsIntPoint(int32_t(floorf(touchData.touchPoint.x)),

--- a/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewParent.cpp
@@ -533,7 +533,7 @@ EmbedLiteViewParent::MousePress(int x, int y, int mstime, unsigned int buttons, 
   }
 
   LOGT("pt[%i,%i], t:%i, bt:%u, mod:%u", x, y, mstime, buttons, modifiers);
-  MultiTouchInput event(MultiTouchInput::MULTITOUCH_START, mstime, TimeStamp(), modifiers);
+  MultiTouchInput event(MultiTouchInput::MULTITOUCH_START, mstime, TimeStamp::Now(), modifiers);
   event.mTouches.AppendElement(SingleTouchData(0,
                                                mozilla::ScreenIntPoint(x, y),
                                                mozilla::ScreenSize(1, 1),
@@ -555,7 +555,7 @@ EmbedLiteViewParent::MouseRelease(int x, int y, int mstime, unsigned int buttons
   }
 
   LOGT("pt[%i,%i], t:%i, bt:%u, mod:%u", x, y, mstime, buttons, modifiers);
-  MultiTouchInput event(MultiTouchInput::MULTITOUCH_END, mstime, TimeStamp(), modifiers);
+  MultiTouchInput event(MultiTouchInput::MULTITOUCH_END, mstime, TimeStamp::Now(), modifiers);
   event.mTouches.AppendElement(SingleTouchData(0,
                                                mozilla::ScreenIntPoint(x, y),
                                                mozilla::ScreenSize(1, 1),
@@ -577,7 +577,7 @@ EmbedLiteViewParent::MouseMove(int x, int y, int mstime, unsigned int buttons, u
   }
 
   LOGT("pt[%i,%i], t:%i, bt:%u, mod:%u", x, y, mstime, buttons, modifiers);
-  MultiTouchInput event(MultiTouchInput::MULTITOUCH_MOVE, mstime, TimeStamp(), modifiers);
+  MultiTouchInput event(MultiTouchInput::MULTITOUCH_MOVE, mstime, TimeStamp::Now(), modifiers);
   event.mTouches.AppendElement(SingleTouchData(0,
                                                mozilla::ScreenIntPoint(x, y),
                                                mozilla::ScreenSize(1, 1),


### PR DESCRIPTION
Without real timestamp (non-zero) values mozilla::layers::Axis reports always zero velocity. This will prevent mozilla::layers::AsyncPanZoomController to handle end of panning (AsyncPanZoomController::HandleEndOfPan) so that fling state would get triggered.

Embedlite TimeStamps are now initialized properly.